### PR TITLE
Changes to allow using IImmutableList<T> instead of ImmutableList<T>

### DIFF
--- a/Fruit.generated.cs
+++ b/Fruit.generated.cs
@@ -36,16 +36,23 @@ namespace ImmutableObjectGraph {
 			return new Optional<T>(value);
 		}
 	}
+
+    public static class Optional {
+        public static Optional<T> For<T>(T value) {
+            return value;
+        }
+    }
+
 	
 	public partial class Basket {
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private static readonly Basket DefaultInstance = new Basket();
 	
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-		private readonly System.Int32 size;
+		private readonly IFruitSize size;
 	
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-		private readonly System.Collections.Immutable.ImmutableList<Fruit> contents;
+		private readonly System.Collections.Immutable.IImmutableList<Fruit> contents;
 	
 		/// <summary>Initializes a new instance of the Basket class.</summary>
 		private Basket()
@@ -53,7 +60,7 @@ namespace ImmutableObjectGraph {
 		}
 	
 		/// <summary>Initializes a new instance of the Basket class.</summary>
-		private Basket(System.Int32 size, System.Collections.Immutable.ImmutableList<Fruit> contents)
+		private Basket(IFruitSize size, System.Collections.Immutable.IImmutableList<Fruit> contents)
 		{
 			this.size = size;
 			this.contents = contents;
@@ -64,11 +71,11 @@ namespace ImmutableObjectGraph {
 			get { return DefaultInstance; }
 		}
 	
-		public System.Int32 Size {
+		public IFruitSize Size {
 			get { return this.size; }
 		}
 	
-		public Basket WithSize(System.Int32 value) {
+		public Basket WithSize(IFruitSize value) {
 			if (value == this.Size) {
 				return this;
 			}
@@ -76,11 +83,11 @@ namespace ImmutableObjectGraph {
 			return new Basket(value, this.Contents);
 		}
 	
-		public System.Collections.Immutable.ImmutableList<Fruit> Contents {
+		public System.Collections.Immutable.IImmutableList<Fruit> Contents {
 			get { return this.contents; }
 		}
 	
-		public Basket WithContents(System.Collections.Immutable.ImmutableList<Fruit> value) {
+		public Basket WithContents(System.Collections.Immutable.IImmutableList<Fruit> value) {
 			if (value == this.Contents) {
 				return this;
 			}
@@ -90,8 +97,8 @@ namespace ImmutableObjectGraph {
 	
 		/// <summary>Returns a new instance of this object with any number of properties changed.</summary>
 		public Basket With(
-			Optional<System.Int32> size = default(Optional<System.Int32>), 
-			Optional<System.Collections.Immutable.ImmutableList<Fruit>> contents = default(Optional<System.Collections.Immutable.ImmutableList<Fruit>>)) {
+			Optional<IFruitSize>size = default(Optional<IFruitSize>), 
+			Optional<System.Collections.Immutable.IImmutableList<Fruit>>contents = default(Optional<System.Collections.Immutable.IImmutableList<Fruit>>)) {
 			return new Basket(
 					size.IsDefined ? size.Value : this.Size,
 					contents.IsDefined ? contents.Value : this.Contents);
@@ -110,10 +117,10 @@ namespace ImmutableObjectGraph {
 			private Basket immutable;
 	
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-			private System.Int32 size;
+			private IFruitSize size;
 	
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-			private System.Collections.Immutable.ImmutableList<Fruit> contents;
+			private System.Collections.Immutable.IImmutableList<Fruit> contents;
 	
 			internal Builder(Basket immutable) {
 				this.immutable = immutable;
@@ -122,7 +129,7 @@ namespace ImmutableObjectGraph {
 				this.contents = immutable.Contents;
 			}
 	
-			public System.Int32 Size {
+			public IFruitSize Size {
 				get {
 					return this.size;
 				}
@@ -135,7 +142,7 @@ namespace ImmutableObjectGraph {
 				}
 			}
 	
-			public System.Collections.Immutable.ImmutableList<Fruit> Contents {
+			public System.Collections.Immutable.IImmutableList<Fruit> Contents {
 				get {
 					return this.contents;
 				}
@@ -151,8 +158,8 @@ namespace ImmutableObjectGraph {
 			public Basket ToImmutable() {
 				if (this.immutable == null) {
 					this.immutable = Basket.Default.With(
-						this.size,
-						this.contents);
+						new Optional<IFruitSize>(this.size),
+						new Optional<System.Collections.Immutable.IImmutableList<Fruit>>(this.contents));
 				}
 	
 				return this.immutable;
@@ -213,8 +220,8 @@ namespace ImmutableObjectGraph {
 	
 		/// <summary>Returns a new instance of this object with any number of properties changed.</summary>
 		public Fruit With(
-			Optional<System.String> color = default(Optional<System.String>), 
-			Optional<System.Int32> skinThickness = default(Optional<System.Int32>)) {
+			Optional<System.String>color = default(Optional<System.String>), 
+			Optional<System.Int32>skinThickness = default(Optional<System.Int32>)) {
 			return new Fruit(
 					color.IsDefined ? color.Value : this.Color,
 					skinThickness.IsDefined ? skinThickness.Value : this.SkinThickness);
@@ -274,8 +281,8 @@ namespace ImmutableObjectGraph {
 			public Fruit ToImmutable() {
 				if (this.immutable == null) {
 					this.immutable = Fruit.Default.With(
-						this.color,
-						this.skinThickness);
+						new Optional<System.String>(this.color),
+						new Optional<System.Int32>(this.skinThickness));
 				}
 	
 				return this.immutable;

--- a/Fruit.tt
+++ b/Fruit.tt
@@ -11,8 +11,10 @@
 		int skinThickness;
 	}
 
-	class Basket {
-		int size;
+    private struct IFruitSize {}
+
+    class Basket {
+		IFruitSize size;
 		Fruit[] contents;
 	}
 #>

--- a/IFruitSize.cs
+++ b/IFruitSize.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ImmutableObjectGraph
+{
+    public interface IFruitSize { }
+}

--- a/ImmutableObjectGraph.csproj
+++ b/ImmutableObjectGraph.csproj
@@ -59,6 +59,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Fruit.tt</DependentUpon>
     </Compile>
+    <Compile Include="IFruitSize.cs" />
+    <Compile Include="NumericFruitSize.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/ImmutableObjectGraph.tt
+++ b/ImmutableObjectGraph.tt
@@ -1,4 +1,5 @@
 ﻿<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
 <#@ Import Namespace="System.Reflection" #>
 <#@ Import Namespace="System.Collections.Generic" #>
 // ------------------------------------------------------------------------------
@@ -39,6 +40,13 @@ namespace <#= this.Namespace #> {
 			return new Optional<T>(value);
 		}
 	}
+
+    public static class Optional {
+        public static Optional<T> For<T>(T value) {
+            return value;
+        }
+    }
+
 <#
 	this.PushIndent("\t");
 	var templateTypes = DiscoverTemplateTypes(this.TemplateType);
@@ -129,11 +137,9 @@ public partial class <#= templateType.Name #> {
 		foreach(var field in fields) {
 			if (!firstInSequence) { Write(", "); }
 			WriteLine("");
-			Write("Optional<");
-			Write(GetTypeName(field.FieldType));
-			Write("> ");
+			Write(GetOptionalTypeName(field.FieldType));
 			Write(CamelCase(field.Name));
-			Write(" = default(Optional<" + GetTypeName(field.FieldType) + ">)");
+			Write(" = default(" + GetOptionalTypeName(field.FieldType) + ")");
 			firstInSequence = false;
 		}
 
@@ -199,7 +205,7 @@ public partial class <#= templateType.Name #> {
 			foreach(var field in fields) {
 				if (!firstInSequence) { Write(","); }
 				WriteLine(""); #>
-					this.<#= CamelCase(field.Name) #><#
+					new <#= GetOptionalTypeName(field.FieldType) #>(this.<#= CamelCase(field.Name) #>)<#
 				firstInSequence = false;
 			} #>
 );
@@ -234,6 +240,8 @@ public partial class <#= templateType.Name #> {
 		while(pendingTypes.Count > 0)
 		{
 			var type = pendingTypes.Dequeue();
+		    if (!type.IsClass)
+		        continue;
 			if (types.Add(type)) {
 				foreach(var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)) {
 					var memberType = field.FieldType;
@@ -269,4 +277,10 @@ public partial class <#= templateType.Name #> {
 
 		return typeName;
 	}
+
+    protected string GetOptionalTypeName(Type type)
+    {
+        return "Optional<" + GetTypeName(type) + ">";
+    }
+
 #>

--- a/NumericFruitSize.cs
+++ b/NumericFruitSize.cs
@@ -1,0 +1,12 @@
+﻿namespace ImmutableObjectGraph
+{
+    public class NumericFruitSize : IFruitSize
+    {
+        public int Value { get; private set; }
+
+        public NumericFruitSize(int value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -3,21 +3,33 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace ImmutableObjectGraph {
-	using System.Collections.Immutable;
-	using System.Reflection;
+namespace ImmutableObjectGraph
+{
+    using System.Collections.Immutable;
+    using System.Reflection;
 
-	class Program {
-		static void Main(string[] args) {
-			var apple = Fruit.Default
-				.With(color: "red", skinThickness: 3);
-			var greenApple = apple.With(color: "green");
-			var greenAppleWithDefaultThickness = greenApple.With(skinThickness: 0);
-			var basket = Basket.Default.WithContents(ImmutableList<Fruit>.Empty.Add(apple)).WithSize(5);
-			var appleBuilder = apple.ToBuilder();
-			appleBuilder.Color = "yellow";
-			var yellowApple = appleBuilder.ToImmutable();
-			Console.WriteLine("You have a {0} apple with {1} skin thickness", apple.Color, apple.SkinThickness);
-		}
-	}
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var apple = Fruit.Default
+                .With(color: "red", skinThickness: 3);
+            var greenApple = apple.With(color: "green");
+            var greenAppleWithDefaultThickness = greenApple.With(skinThickness: 0);
+
+            ImmutableList<Fruit> immutableFruits = ImmutableList<Fruit>.Empty.Add(apple);
+            IImmutableList<Fruit> fruits = immutableFruits;
+            var numericFruitSize = new NumericFruitSize(5);
+            IFruitSize size = numericFruitSize;
+
+            var basket = Basket.Default.With(contents: immutableFruits, size: numericFruitSize);
+            basket = Basket.Default.With(contents: Optional.For(fruits), size: Optional.For(size));
+            basket = Basket.Default.WithContents(fruits).WithSize(size);
+
+            var appleBuilder = apple.ToBuilder();
+            appleBuilder.Color = "yellow";
+            var yellowApple = appleBuilder.ToImmutable();
+            Console.WriteLine("You have a {0} apple with {1} skin thickness", apple.Color, apple.SkinThickness);
+        }
+    }
 }


### PR DESCRIPTION
First change set makes the template use IImutableList<T> instead of ImmutableList<T>, which in itself doesn't work because ToImmutable() cannot pass interface types variables directly to the With() method.

Second change set fixes this issue for the ToImmutable() method by explicit creating Optional<T> instances. This issue is still present, and using the With() method with a variable typed as an interface will still not work - if it is typed as an implementation of that interface however, it does work - as illustrated by the various basket cases in Program.

Personally I prefer this drawback to being stuck with a specific implementation.
