### PR TITLE
Upgrade to ImmutableCollections 1.1, changes to support ImmutableArray

### DIFF
--- a/ImmutableObjectGraph/CollectionExtensions.cs
+++ b/ImmutableObjectGraph/CollectionExtensions.cs
@@ -33,7 +33,13 @@
 			return list.SequenceEqual(values) ? list : list.Clear().AddRange(values);
 		}
 
-		public static ImmutableSortedSet<T> Replace<T>(this ImmutableSortedSet<T> set, T oldValue, T newValue) {
+		public static ImmutableArray<T> ResetContents<T>(this ImmutableArray<T> arr, IEnumerable<T> values)
+		{
+			return arr.SequenceEqual(values) ? arr : ImmutableArray.CreateRange(values);
+		}
+
+		public static ImmutableSortedSet<T> Replace<T>(this ImmutableSortedSet<T> set, T oldValue, T newValue)
+		{
 			var alteredSet = set.Remove(oldValue);
 			return alteredSet != set ? alteredSet.Add(newValue) : set;
 		}

--- a/ImmutableObjectGraph/ImmutableObjectGraph.Builders.tt
+++ b/ImmutableObjectGraph/ImmutableObjectGraph.Builders.tt
@@ -56,9 +56,13 @@ public <#= templateType.HasAncestor ? "new ": "" #>partial class Builder<#
 <#		} #>
 
 	public <#= templateType.HasAncestor ? "new ": "" #><#= templateType.TypeName #> ToImmutable() {
-<#			foreach(var templateField in templateType.AllFields.Where(f => !f.IsPrimitiveType)) { #>
+<#			foreach(var templateField in templateType.AllFields.Where(f => !f.IsPrimitiveType)) {
+				if (templateField.IsValueType) { #>
+		var <#= templateField.NameCamelCase #> = this.<#= templateField.NameCamelCase #>.IsDefined ? this.<#= templateField.NameCamelCase #>.Value.ToImmutable() : this.immutable.<#= templateField.NamePascalCase #>;
+<#				} else { #>
 		var <#= templateField.NameCamelCase #> = this.<#= templateField.NameCamelCase #>.IsDefined ? (this.<#= templateField.NameCamelCase #>.Value != null ? this.<#= templateField.NameCamelCase #>.Value.ToImmutable() : null) : this.immutable.<#= templateField.NamePascalCase #>;
-<#			} #>
+<#				}
+			} #>
 		return this.immutable = this.immutable<# if (templateType.LocalFields.Count > 0) { #>.With(<#
 		bool firstInSequence = true;
 		foreach(var field in templateType.AllFields) {

--- a/ImmutableObjectGraph/ImmutableObjectGraph.Discovery.tt
+++ b/ImmutableObjectGraph/ImmutableObjectGraph.Discovery.tt
@@ -343,6 +343,14 @@ protected class MetaType {
 			get { return !TemplateTypes.Any(mt => mt.Type.IsEquivalentTo(this.FieldType)) && !this.IsCollection; }
 		}
 			
+		public bool IsValueType {
+			get { return this.Field.FieldType.IsValueType; }
+		}
+			
+		public bool IsClassType {
+			get { return this.Field.FieldType.IsClass; }
+		}
+			
 		public Type ElementType {
 			get { return GetTypeOrCollectionMemberType(this.Field.FieldType); }
 		}

--- a/ImmutableObjectGraph/ImmutableObjectGraph.csproj
+++ b/ImmutableObjectGraph/ImmutableObjectGraph.csproj
@@ -44,9 +44,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.0.8.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable, Version=1.1.20.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.8-beta\lib\net45\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.1.20-beta\lib\net45\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/ImmutableObjectGraph/ImmutableObjectGraph.tt
+++ b/ImmutableObjectGraph/ImmutableObjectGraph.tt
@@ -1,6 +1,6 @@
 ﻿<#@ assembly name="System.Core" #>
 <#@ assembly name="System.Runtime" #>
-<#@ assembly name="$(ProjectDir)..\packages\Microsoft.Bcl.Immutable.1.0.8-beta\lib\net45\System.Collections.Immutable.dll" #>
+<#@ assembly name="$(ProjectDir)..\packages\Microsoft.Bcl.Immutable.1.1.20-beta\lib\net45\System.Collections.Immutable.dll" #>
 <#@ assembly name="$(ProjectDir)bin\debug\ImmutableObjectGraph.dll" #>
 <#@ Import Namespace="ImmutableObjectGraph" #>
 <#@ Import Namespace="System.Collections.Generic" #>

--- a/ImmutableObjectGraph/packages.config
+++ b/ImmutableObjectGraph/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl.Immutable" version="1.0.8-beta" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Immutable" version="1.1.20-beta" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
It wasn't possible to use ImmutableArray (re-introduced with
ImmutableCollections 1.1) with ImmutableObjectGraph, because some of the
generated code for builders assumes that collections can be tested
against null. This skips the null check for value-type collections such
as ImmutableArray.
