### PR TITLE
Adding an [External] Attribute

### DIFF
--- a/ImmutableObjectGraph/ExternalAttribute.cs
+++ b/ImmutableObjectGraph/ExternalAttribute.cs
@@ -1,0 +1,18 @@
+﻿namespace ImmutableObjectGraph
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Text;
+	using System.Threading.Tasks;
+
+	/// <summary>
+	/// Indicates that the we're forward declaring another type which will be declared elsewhere
+	/// in the project, outside of the .tt file. This type will be referenced by the types in,
+	/// the .tt file, but will not be part of the output.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
+	public sealed class ExternalAttribute : Attribute
+	{
+	}
+}

--- a/ImmutableObjectGraph/ImmutableObjectGraph.Discovery.tt
+++ b/ImmutableObjectGraph/ImmutableObjectGraph.Discovery.tt
@@ -23,8 +23,10 @@ protected static void DiscoverTemplateTypes() {
 	TemplateTypes = new HashSet<MetaType>();
 	var pendingTypes = new Queue<Type>();
 
-	Func<Type, bool> includeTypeTest = t => t.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() == null 
-						&& !HiddenTypes.Any(ht => ht.IsEquivalentTo(t));
+	Func<Type, bool> includeTypeTest = t =>
+			t.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() == null &&
+			t.GetCustomAttribute<ImmutableObjectGraph.ExternalAttribute>() == null &&
+			!HiddenTypes.Any(ht => ht.IsEquivalentTo(t));
 
 	foreach (var nestedType in rootType.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public)) {
 		if (includeTypeTest(nestedType)) {
@@ -40,7 +42,8 @@ protected static void DiscoverTemplateTypes() {
 			foreach(var field in metaType.LocalFields) {
 				var memberType = field.ElementType;
 
-				if (memberType.DeclaringType == type.DeclaringType) { // if this is a type that also appears in the T4 template
+				if (memberType.DeclaringType == type.DeclaringType &&
+					includeTypeTest(memberType)) { // if this is a type that also appears in the T4 template
 					pendingTypes.Enqueue(memberType);
 				}
 			}
@@ -290,7 +293,7 @@ protected class MetaType {
 		var fields = ImmutableList.Create<MetaField>();
 		if (ancestor != this) {
 			fields = fields.AddRange(this.LocalFields)
-				            .InsertRange(0, this.Ancestor.GetFieldsBeyond(ancestor));
+							.InsertRange(0, this.Ancestor.GetFieldsBeyond(ancestor));
 		}
 
 		return fields;

--- a/ImmutableObjectGraph/ImmutableObjectGraph.csproj
+++ b/ImmutableObjectGraph/ImmutableObjectGraph.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionExtensions.cs" />
+    <Compile Include="ExternalAttribute.cs" />
     <Compile Include="Optional.cs" />
     <Compile Include="Optional`1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Immutable Objects can reference types defined in a previously-compiled
DLL via the <#@ assembly #> directive. However, there's no easy way to
reference types defined in the _same_ assembly as your .tt file, because
that would create a circular dependency between the outputs of the T4
preprocessor and the C# compiler.

This change adds an [External] attribute that can be used within your
.tt file to enable references to an external type. Usage is fairly
simple:

In your .tt file:

``` C#
[External]
enum FruitColor { }       // <-- note empty braces

class Fruit {             // an ordinary Immutable declaration
    FruitColor color;       // use of FruitColor like any other type
    // other declarations
}
```

In any .cs file in the same project:

``` C#
// The real declaration of FruitColor
enum FruitColor {
    Golden,
    Green,
    Yellow
}
```

This works for any type: enums, structs, or classes. (Although if your
immutable object contains references to mutable classes, I take no blame
for your design!)

Under the hood, the [External] attribute just causes a type to be
compiled in as normal, but not included in the generated output. Thus
you'll end up with a .generated.cs file that uses the type but doesn't
define it. When that's run through the C# compiler alongside a normal
.cs file that defines the type, everything ends up working nicely.
