### PR TITLE
Support empty classes in the middle of type hierarchy

### DIFF
--- a/src/ImmutableObjectGraph.CodeGeneration.Roslyn/CodeGen.cs
+++ b/src/ImmutableObjectGraph.CodeGeneration.Roslyn/CodeGen.cs
@@ -855,6 +855,7 @@
             protected abstract void GenerateCore();
         }
 
+        [DebuggerDisplay("{TypeSymbol.Name}")]
         protected struct MetaType
         {
             private CodeGen generator;

--- a/src/ImmutableObjectGraph.CodeGeneration.Tests/CodeGenTests.cs
+++ b/src/ImmutableObjectGraph.CodeGeneration.Tests/CodeGenTests.cs
@@ -191,6 +191,12 @@
 
         }
 
+        [Fact]
+        public async Task Hierarchy3Levels_Compiles()
+        {
+            await this.GenerateFromStreamAsync("Hierarchy3Levels");
+        }
+
         protected async Task<GenerationResult> GenerateFromStreamAsync(string testName)
         {
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(this.GetType().Namespace + ".TestSources." + testName + ".cs"))

--- a/src/ImmutableObjectGraph.CodeGeneration.Tests/ImmutableObjectGraph.CodeGeneration.Tests.csproj
+++ b/src/ImmutableObjectGraph.CodeGeneration.Tests/ImmutableObjectGraph.CodeGeneration.Tests.csproj
@@ -123,6 +123,7 @@
   <ItemGroup>
     <Compile Include="CodeGenTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Include="TestSources\Hierarchy3Levels.cs" />
     <Compile Include="TestSources\MSBuild.cs">
       <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
     </Compile>

--- a/src/ImmutableObjectGraph.CodeGeneration.Tests/TestSources/Hierarchy3Levels.cs
+++ b/src/ImmutableObjectGraph.CodeGeneration.Tests/TestSources/Hierarchy3Levels.cs
@@ -2,7 +2,10 @@
 abstract partial class L1 { }
 
 [ImmutableObjectGraph.CodeGeneration.GenerateImmutable]
-abstract partial class L2 : L1 { }
+abstract partial class L2 : L1
+{
+    // This in-between type intentionally has no members.
+}
 
 [ImmutableObjectGraph.CodeGeneration.GenerateImmutable]
 partial class L3 : L2

--- a/src/ImmutableObjectGraph.CodeGeneration.Tests/TestSources/Hierarchy3Levels.cs
+++ b/src/ImmutableObjectGraph.CodeGeneration.Tests/TestSources/Hierarchy3Levels.cs
@@ -1,0 +1,11 @@
+﻿[ImmutableObjectGraph.CodeGeneration.GenerateImmutable]
+abstract partial class L1 { }
+
+[ImmutableObjectGraph.CodeGeneration.GenerateImmutable]
+abstract partial class L2 : L1 { }
+
+[ImmutableObjectGraph.CodeGeneration.GenerateImmutable]
+partial class L3 : L2
+{
+    string foo;
+}


### PR DESCRIPTION
This fixes code generation when a type is empty and both derives from and serves as a base class to other immutable classes.