### PR TITLE
Explicitly cast recursive field to IEnumerable in generated GetEnumerator methods

### DIFF
--- a/src/ImmutableObjectGraph.Generation.Tests/CodeGenTests.cs
+++ b/src/ImmutableObjectGraph.Generation.Tests/CodeGenTests.cs
@@ -75,6 +75,12 @@
         }
 
         [Fact]
+        public async Task ImmutableArray_CanBuild()
+        {
+            var result = await this.GenerateFromStreamAsync("ImmutableArray");
+        }
+
+        [Fact]
         public async Task OneScalarFieldAndEmptyDerived_HasCreateMethod()
         {
             var result = await this.GenerateFromStreamAsync("OneScalarFieldAndEmptyDerived");

--- a/src/ImmutableObjectGraph.Generation.Tests/ImmutableObjectGraph.Generation.Tests.csproj
+++ b/src/ImmutableObjectGraph.Generation.Tests/ImmutableObjectGraph.Generation.Tests.csproj
@@ -58,6 +58,7 @@
       <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
     </Compile>
     <EmbeddedResource Include="TestSources\ByteArray.cs" />
+    <EmbeddedResource Include="TestSources\ImmutableArray.cs" />
     <Compile Include="TestSources\Generations.cs">
       <Generator>MSBuild:GenerateCodeFromAttributes</Generator>
     </Compile>

--- a/src/ImmutableObjectGraph.Generation.Tests/TestSources/ImmutableArray.cs
+++ b/src/ImmutableObjectGraph.Generation.Tests/TestSources/ImmutableArray.cs
@@ -1,0 +1,10 @@
+﻿namespace ImmutableObjectGraph.Generation.Tests.TestSources
+{
+    using System.Collections.Immutable;
+
+    [GenerateImmutable]
+    partial class Node
+    {
+        readonly ImmutableArray<Node> children;
+    }
+}

--- a/src/ImmutableObjectGraph.Generation/CodeGen+EnumerableRecursiveParentGen.cs
+++ b/src/ImmutableObjectGraph.Generation/CodeGen+EnumerableRecursiveParentGen.cs
@@ -74,15 +74,18 @@
             {
                 this.baseTypes.Add(SyntaxFactory.SimpleBaseType(Syntax.IEnumerableOf(this.generator.applyToMetaType.RecursiveType.TypeSyntax)));
 
-                // return this.<#=templateType.RecursiveField.NameCamelCase#>.GetEnumerator();
+                // return ((IEnumerable<RecursiveType>)this.<#=templateType.RecursiveField.NameCamelCase#>).GetEnumerator();
                 var body = SyntaxFactory.Block(
                     SyntaxFactory.ReturnStatement(
                         SyntaxFactory.InvocationExpression(
                             SyntaxFactory.MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
-                                Syntax.ThisDot(SyntaxFactory.IdentifierName(this.generator.applyToMetaType.RecursiveField.Name)),
-                                SyntaxFactory.IdentifierName(nameof(IEnumerable<int>.GetEnumerator))),
-                            SyntaxFactory.ArgumentList())));
+                                SyntaxFactory.ParenthesizedExpression(
+                                    SyntaxFactory.CastExpression(
+                                        Syntax.IEnumerableOf(GetFullyQualifiedSymbolName(this.generator.applyToMetaType.RecursiveField.ElementType)),
+                                        Syntax.ThisDot(SyntaxFactory.IdentifierName(this.generator.applyToMetaType.RecursiveField.Name)))),
+                                            SyntaxFactory.IdentifierName(nameof(IEnumerable<int>.GetEnumerator))),
+                                        SyntaxFactory.ArgumentList())));
 
                 // public System.Collections.Generic.IEnumerator<RecursiveType> GetEnumerator()
                 this.innerMembers.Add(


### PR DESCRIPTION
Fixes compile error when using an ImmutableArray as collection type.