### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ partial class Fruit
         }
     }
 
-#pragma warning disable 649 // field initialization is optional in user code
+# pragma warning disable 649 // field initialization is optional in user code
 
     private struct Template
     {
         internal System.String Color;
         internal System.Int32 SkinThickness;
     }
-#pragma warning restore 649
+# pragma warning restore 649
 }
 ```
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
