### PR TITLE
Internalized DeclarationComputer from Roslyn, bump to v1.3

### DIFF
--- a/src/ImmutableObjectGraph.Generation/Roslyn/CSharpDeclarationComputer.cs
+++ b/src/ImmutableObjectGraph.Generation/Roslyn/CSharpDeclarationComputer.cs
@@ -1,0 +1,286 @@
+﻿#pragma warning disable // this came from Roslyn code
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace ImmutableObjectGraph.Generation.Roslyn
+{
+    internal class CSharpDeclarationComputer : DeclarationComputer
+    {
+        public static ImmutableArray<DeclarationInfo> GetDeclarationsInSpan(SemanticModel model, TextSpan span, bool getSymbol, CancellationToken cancellationToken)
+        {
+            var builder = ImmutableArray.CreateBuilder<DeclarationInfo>();
+            ComputeDeclarations(model, model.SyntaxTree.GetRoot(cancellationToken),
+                (node, level) => !node.Span.OverlapsWith(span) || InvalidLevel(level),
+                getSymbol, builder, null, cancellationToken);
+            return builder.ToImmutable();
+        }
+
+        public static ImmutableArray<DeclarationInfo> GetDeclarationsInNode(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken, int? levelsToCompute = null)
+        {
+            var builder = ImmutableArray.CreateBuilder<DeclarationInfo>();
+            ComputeDeclarations(model, node, (n, level) => InvalidLevel(level), getSymbol, builder, levelsToCompute, cancellationToken);
+            return builder.ToImmutable();
+        }
+
+        private static bool InvalidLevel(int? level)
+        {
+            return level.HasValue && level.Value <= 0;
+        }
+
+        private static int? DecrementLevel(int? level)
+        {
+            return level.HasValue ? level - 1 : level;
+        }
+
+        internal static void ComputeDeclarations(
+            SemanticModel model,
+            SyntaxNode node,
+            Func<SyntaxNode, int?, bool> shouldSkip,
+            bool getSymbol,
+            ImmutableArray<DeclarationInfo>.Builder builder,
+            int? levelsToCompute,
+            CancellationToken cancellationToken)
+        {
+            if (shouldSkip(node, levelsToCompute))
+            {
+                return;
+            }
+
+            var newLevel = DecrementLevel(levelsToCompute);
+
+            switch (node.Kind())
+            {
+                case SyntaxKind.NamespaceDeclaration:
+                    {
+                        var ns = (NamespaceDeclarationSyntax)node;
+                        foreach (var decl in ns.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken));
+
+                        NameSyntax name = ns.Name;
+                        while (name.Kind() == SyntaxKind.QualifiedName)
+                        {
+                            name = ((QualifiedNameSyntax)name).Left;
+                            var declaredSymbol = getSymbol ? model.GetSymbolInfo(name, cancellationToken).Symbol : null;
+                            builder.Add(new DeclarationInfo(name, ImmutableArray<SyntaxNode>.Empty, declaredSymbol));
+                        }
+
+                        return;
+                    }
+
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.StructDeclaration:
+                case SyntaxKind.InterfaceDeclaration:
+                    {
+                        var t = (TypeDeclarationSyntax)node;
+                        foreach (var decl in t.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.EnumDeclaration:
+                    {
+                        var t = (EnumDeclarationSyntax)node;
+                        foreach (var decl in t.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.EnumMemberDeclaration:
+                    {
+                        var t = (EnumMemberDeclarationSyntax)node;
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, t.EqualsValue, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.DelegateDeclaration:
+                    {
+                        var t = (DelegateDeclarationSyntax)node;
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.EventDeclaration:
+                    {
+                        var t = (EventDeclarationSyntax)node;
+                        foreach (var decl in t.AccessorList.Accessors) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.EventFieldDeclaration:
+                case SyntaxKind.FieldDeclaration:
+                    {
+                        var t = (BaseFieldDeclarationSyntax)node;
+                        foreach (var decl in t.Declaration.Variables)
+                        {
+                            builder.Add(GetDeclarationInfo(model, decl, getSymbol, decl.Initializer, cancellationToken));
+                        }
+
+                        return;
+                    }
+
+                case SyntaxKind.ArrowExpressionClause:
+                    {
+                        // Arrow expression clause declares getter symbol for properties and indexers.
+                        var parentProperty = node.Parent as BasePropertyDeclarationSyntax;
+                        if (parentProperty != null)
+                        {
+                            builder.Add(GetExpressionBodyDeclarationInfo(parentProperty, (ArrowExpressionClauseSyntax)node, model, getSymbol, cancellationToken));
+                        }
+
+                        return;
+                    }
+
+                case SyntaxKind.PropertyDeclaration:
+                    {
+                        var t = (PropertyDeclarationSyntax)node;
+                        if (t.AccessorList != null)
+                        {
+                            foreach (var decl in t.AccessorList.Accessors) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        }
+
+                        if (t.ExpressionBody != null)
+                        {
+                            ComputeDeclarations(model, t.ExpressionBody, shouldSkip, getSymbol, builder, levelsToCompute, cancellationToken);
+                        }
+
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken, t.Initializer));
+                        return;
+                    }
+
+                case SyntaxKind.IndexerDeclaration:
+                    {
+                        var t = (IndexerDeclarationSyntax)node;
+                        if (t.AccessorList != null)
+                        {
+                            foreach (var decl in t.AccessorList.Accessors)
+                            {
+                                ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                            }
+                        }
+
+                        if (t.ExpressionBody != null)
+                        {
+                            ComputeDeclarations(model, t.ExpressionBody, shouldSkip, getSymbol, builder, levelsToCompute, cancellationToken);
+                        }
+
+                        var codeBlocks = t.ParameterList != null ? t.ParameterList.Parameters.Select(p => p.Default) : Enumerable.Empty<SyntaxNode>();
+
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.AddAccessorDeclaration:
+                case SyntaxKind.RemoveAccessorDeclaration:
+                case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.GetAccessorDeclaration:
+                    {
+                        var t = (AccessorDeclarationSyntax)node;
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, t.Body, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.ConstructorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
+                case SyntaxKind.DestructorDeclaration:
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.OperatorDeclaration:
+                    {
+                        var t = (BaseMethodDeclarationSyntax)node;
+                        var codeBlocks = t.ParameterList != null ? t.ParameterList.Parameters.Select(p => p.Default) : Enumerable.Empty<SyntaxNode>();
+                        codeBlocks = codeBlocks.Concat(new[] { t.Body });
+
+                        var ctorDecl = t as ConstructorDeclarationSyntax;
+                        if (ctorDecl != null && ctorDecl.Initializer != null)
+                        {
+                            codeBlocks = codeBlocks.Concat(new[] { ctorDecl.Initializer });
+                        }
+
+                        var expressionBody = GetExpressionBodySyntax(t);
+                        if (expressionBody != null)
+                        {
+                            codeBlocks = codeBlocks.Concat(new[] { expressionBody });
+                        }
+
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken));
+                        return;
+                    }
+
+                case SyntaxKind.CompilationUnit:
+                    {
+                        var t = (CompilationUnitSyntax)node;
+                        foreach (var decl in t.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
+                        return;
+                    }
+
+                default:
+                    return;
+            }
+        }
+
+        private static DeclarationInfo GetExpressionBodyDeclarationInfo(
+            BasePropertyDeclarationSyntax declarationWithExpressionBody,
+            ArrowExpressionClauseSyntax expressionBody,
+            SemanticModel model,
+            bool getSymbol,
+            CancellationToken cancellationToken)
+        {
+            // TODO: use 'model.GetDeclaredSymbol(expressionBody)' when compiler is fixed to return the getter symbol for it.
+            var declaredAccessor = getSymbol ? (model.GetDeclaredSymbol(declarationWithExpressionBody, cancellationToken) as IPropertySymbol)?.GetMethod : null;
+
+            return new DeclarationInfo(
+                declaredNode: expressionBody,
+                executableCodeBlocks: ImmutableArray.Create<SyntaxNode>(expressionBody),
+                declaredSymbol: declaredAccessor);
+        }
+
+        /// <summary>
+        /// Gets the expression-body syntax from an expression-bodied member. The
+        /// given syntax must be for a member which could contain an expression-body.
+        /// </summary>
+        internal static ArrowExpressionClauseSyntax GetExpressionBodySyntax(CSharpSyntaxNode node)
+        {
+            ArrowExpressionClauseSyntax arrowExpr = null;
+            switch (node.Kind())
+            {
+                // The ArrowExpressionClause is the declaring syntax for the
+                // 'get' SourcePropertyAccessorSymbol of properties and indexers.
+                case SyntaxKind.ArrowExpressionClause:
+                    arrowExpr = (ArrowExpressionClauseSyntax)node;
+                    break;
+                case SyntaxKind.MethodDeclaration:
+                    arrowExpr = ((MethodDeclarationSyntax)node).ExpressionBody;
+                    break;
+                case SyntaxKind.OperatorDeclaration:
+                    arrowExpr = ((OperatorDeclarationSyntax)node).ExpressionBody;
+                    break;
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    arrowExpr = ((ConversionOperatorDeclarationSyntax)node).ExpressionBody;
+                    break;
+                case SyntaxKind.PropertyDeclaration:
+                    arrowExpr = ((PropertyDeclarationSyntax)node).ExpressionBody;
+                    break;
+                case SyntaxKind.IndexerDeclaration:
+                    arrowExpr = ((IndexerDeclarationSyntax)node).ExpressionBody;
+                    break;
+                case SyntaxKind.ConstructorDeclaration:
+                case SyntaxKind.DestructorDeclaration:
+                    return null;
+                default:
+                    // Don't throw, just use for the assert in case this is used in the semantic model
+                    ////ExceptionUtilities.UnexpectedValue(node.Kind());
+                    break;
+            }
+            return arrowExpr;
+        }
+    }
+}

--- a/src/ImmutableObjectGraph.Generation/Roslyn/DeclarationComputer.cs
+++ b/src/ImmutableObjectGraph.Generation/Roslyn/DeclarationComputer.cs
@@ -1,0 +1,39 @@
+﻿#pragma warning disable // this came from Roslyn code
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace ImmutableObjectGraph.Generation.Roslyn
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using Microsoft.CodeAnalysis;
+
+    internal class DeclarationComputer
+    {
+        internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, IEnumerable<SyntaxNode> executableCodeBlocks, CancellationToken cancellationToken)
+        {
+            var declaredSymbol = getSymbol ? model.GetDeclaredSymbol(node, cancellationToken) : null;
+            var codeBlocks = executableCodeBlocks?.Where(c => c != null).ToImmutableArray() ?? ImmutableArray<SyntaxNode>.Empty;
+            return new DeclarationInfo(node, codeBlocks, declaredSymbol);
+        }
+
+        internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken)
+        {
+            return GetDeclarationInfo(model, node, getSymbol, (IEnumerable<SyntaxNode>)null, cancellationToken);
+        }
+
+        internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, SyntaxNode executableCodeBlock, CancellationToken cancellationToken)
+        {
+            var declaredSymbol = getSymbol ? model.GetDeclaredSymbol(node, cancellationToken) : null;
+            var codeBlock = executableCodeBlock == null ? ImmutableArray<SyntaxNode>.Empty : ImmutableArray.Create(executableCodeBlock);
+            return new DeclarationInfo(node, codeBlock, declaredSymbol);
+        }
+
+        internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken, params SyntaxNode[] executableCodeBlocks)
+        {
+            return GetDeclarationInfo(model, node, getSymbol, executableCodeBlocks.AsEnumerable(), cancellationToken);
+        }
+    }
+}

--- a/src/ImmutableObjectGraph.Generation/Roslyn/DeclarationInfo.cs
+++ b/src/ImmutableObjectGraph.Generation/Roslyn/DeclarationInfo.cs
@@ -1,0 +1,49 @@
+﻿#pragma warning disable // this came from Roslyn code
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Validation;
+
+namespace ImmutableObjectGraph.Generation.Roslyn
+{
+    /// <summary>
+    /// Struct containing information about a source declaration.
+    /// </summary>
+    internal struct DeclarationInfo
+    {
+        private readonly SyntaxNode _declaredNode;
+        private readonly ImmutableArray<SyntaxNode> _executableCodeBlocks;
+        private readonly ISymbol _declaredSymbol;
+
+        internal DeclarationInfo(SyntaxNode declaredNode, ImmutableArray<SyntaxNode> executableCodeBlocks, ISymbol declaredSymbol)
+        {
+            Requires.NotNull(declaredNode, nameof(declaredNode));
+
+            // TODO: Below assert has been commented out as is not true for VB field decls where multiple variables can share same initializer.
+            // Declared node is the identifier, which doesn't contain the initializer. Can we tweak the assert somehow to handle this case?
+            // Debug.Assert(executableCodeBlocks.All(n => n.Ancestors().Contains(declaredNode)));
+
+            _declaredNode = declaredNode;
+            _executableCodeBlocks = executableCodeBlocks;
+            _declaredSymbol = declaredSymbol;
+        }
+
+        /// <summary>
+        /// Topmost syntax node for this declaration.
+        /// </summary>
+        public SyntaxNode DeclaredNode { get { return _declaredNode; } }
+
+        /// <summary>
+        /// Syntax nodes for executable code blocks (method body, initializers, etc.) associated with this declaration.
+        /// </summary>
+        public ImmutableArray<SyntaxNode> ExecutableCodeBlocks { get { return _executableCodeBlocks; } }
+
+        /// <summary>
+        /// Symbol declared by this declaration.
+        /// </summary>
+        public ISymbol DeclaredSymbol { get { return _declaredSymbol; } }
+    }
+}

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2-beta",
+  "version": "1.3-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d\\.\\d" // we also release from release branches


### PR DESCRIPTION
Actually copied the files from CodeGeneration.Roslyn:
https://github.com/AArnott/CodeGeneration.Roslyn/tree/782053e8db9122c1de994f6e973c6be36c4cac85/src/CodeGeneration.Roslyn/Roslyn

These files will be dropped from future versions of that package, and are only internally needed for this project. So the files were copied, had type visibility changed to internal, and namespace changed to ImmutableObjectGraph.Generation.Roslyn.

See:
* https://github.com/AArnott/CodeGeneration.Roslyn/pull/94
* https://github.com/AArnott/CodeGeneration.Roslyn/pull/93